### PR TITLE
Update License Download Link to New File Path

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -144,7 +144,7 @@
   <h1 class="mobile-title">Open Data Ownership License (ODOL)</h1>
   <p class="mobile-text">The Open Data Ownership License empowers individuals and organizations to maintain ownership and transparency over their data in the age of AI.</p>
   <div class="btn-group">
-    <a class="btn waves-effect waves-light teal" target="_blank" href="https://github.com/morozow/odol-license/blob/main/LICENSE">Download the License</a>
+    <a class="btn waves-effect waves-light teal" target="_blank" href="https://github.com/morozow/odol-license/blob/main/core-license/LICENSE_ODOL">Download the License</a>
     <a class="btn-flat grey waves-effect waves-dark lighten-2 black-text" target="_blank" href="https://github.com/morozow/odol-license/blob/main/README.md">Learn More</a>
   </div>
   <h6 class="mobile-footer guiding-principle">Your Data. Your Decisions. Your Rights.</h6>
@@ -223,7 +223,7 @@
 
   <div class="contribution">
     <div class="btn-group">
-      <a class="btn waves-effect waves-light teal" target="_blank" href="https://github.com/morozow/odol-license/blob/main/LICENSE">Download the License</a>
+      <a class="btn waves-effect waves-light teal" target="_blank" href="https://github.com/morozow/odol-license/blob/main/core-license/LICENSE_ODOL">Download the License</a>
       <a class="btn-flat grey waves-effect waves-dark lighten-2 black-text" target="_blank" href="https://github.com/morozow/odol-license/blob/main/README.md">Learn More</a>
     </div>
   </div>


### PR DESCRIPTION
## 📝 Summary

This pull request updates the "Download the License" button hyperlink to point to the new file path located under `core-license/LICENSE_ODOL`. This change ensures that users always access the correct and most up-to-date version of the license document.

---

## 🔍 Changes Introduced

1. **Updated License Download Link**  
   - Modified the `href` attribute of the **"Download the License"** button to reflect the updated file path.  
   - Ensures users are directed to the correct license file in the repository.

2. **Code Consistency and Clarity**  
   - Verified that the link adheres to existing URL formatting standards.  
   - Ensured no other references to the old path remain in the codebase.

---

## 📂 Modified Files

- `index.html`  